### PR TITLE
WON-356-performance-itineraries-verbeteren

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.py]
+indent_size = 4
+
+[Dockerfile, *.{json,yml,yaml,sh,bash,ini,conf,md}]
+indent_size = 2
+
+[*.{md,markdown}]
+trim_trailing_whitespace = false
+
+# Makefile
+[Makefile]
+indent_style = tab

--- a/app/apps/cases/serializers.py
+++ b/app/apps/cases/serializers.py
@@ -30,4 +30,10 @@ class CaseSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(serializers.DictField())
     def get_data(self, obj):
+        # Prefer pre-fetched batch data to avoid per-item external requests
+        cache = self.context.get("cases_data_cache")
+        if cache is not None:
+            data = cache.get(str(obj.case_id))
+            if data is not None:
+                return data
         return obj.data_context(self.context)

--- a/app/utils/queries_zaken_api.py
+++ b/app/utils/queries_zaken_api.py
@@ -39,6 +39,7 @@ def fetch_cases_data(
 
     - Uses /cases/data/?ids=... in a single request.
     - Accepts ids as strings or ints; keys in the result are strings.
+    - Injects a 404 case for each id that is not found.
     """
     unique_ids: List[str] = list({str(i) for i in ids if i is not None})
     if not unique_ids:
@@ -60,5 +61,14 @@ def fetch_cases_data(
     for item in items:
         # Zaken IDs are integers; TOP stores them as strings in Case.case_id
         result[str(item["id"])] = item
+
+    # Inject a 404 case for each id that is not found.
+    from apps.cases.models import CASE_404
+
+    for case_id in unique_ids:
+        if case_id not in result:
+            deleted_case = CASE_404.copy()
+            deleted_case["id"] = int(case_id)
+            result[case_id] = deleted_case
 
     return result

--- a/app/utils/queries_zaken_api.py
+++ b/app/utils/queries_zaken_api.py
@@ -1,6 +1,8 @@
 # TODO: Tests for this
 import logging
+from typing import Dict, Iterable, List
 
+import requests
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -25,3 +27,38 @@ def date_to_string(date):
 def assert_allow_push():
     assert settings.ZAKEN_API_URL, "ZAKEN_API_URL is not configured in settings."
     assert settings.PUSH_ZAKEN, "Pushes disabled"
+
+
+def fetch_cases_data(
+    ids: Iterable[str],
+    auth_header=None,
+    timeout: int = 60,
+) -> Dict[str, dict]:
+    """
+    Batch fetch case details from Zaken and return a dict keyed by stringified id.
+
+    - Uses /cases/data/?ids=... in a single request.
+    - Accepts ids as strings or ints; keys in the result are strings.
+    """
+    unique_ids: List[str] = list({str(i) for i in ids if i is not None})
+    if not unique_ids:
+        return {}
+
+    base_url = f"{settings.ZAKEN_API_URL}/cases/data/"
+    headers = get_headers(auth_header)
+
+    params = {
+        "ids": ",".join(unique_ids),
+        "page_size": len(unique_ids),
+    }
+    resp = requests.get(base_url, params=params, headers=headers, timeout=timeout)
+    resp.raise_for_status()
+    payload = resp.json()
+    items = payload.get("results", payload)
+
+    result: Dict[str, dict] = {}
+    for item in items:
+        # Zaken IDs are integers; TOP stores them as strings in Case.case_id
+        result[str(item["id"])] = item
+
+    return result


### PR DESCRIPTION
- Adds [EditorConfig](https://editorconfig.org/) file, so dev IDEs will show/save files consistently;
- Moves the fetch case data to a batch method, leverages an existing `zaken-backend` endpoint with a new filter on case IDs, while keeping the existing 404 handling intact.